### PR TITLE
fix tensor device difference

### DIFF
--- a/DDECC.py
+++ b/DDECC.py
@@ -188,7 +188,7 @@ class DDECCT(nn.Module):
         #Single sampling from the real p dist.
         sum_syndrome =  (torch.matmul(sign_to_bin(torch.sign(yt.to(self.device))),self.pc_matrix) % 2).round().long().sum(-1)
         # assert sum_syndrome.max() <= self.pc_matrix.shape[1] and sum_syndrome.min() >= 0
-        t = sum_syndrome
+        t = sum_syndrome.cpu()
         # Model output
         noise_mul_pred = self(yt.to(self.device), sum_syndrome.to(self.device)).cpu()# predicted multiplicative noise
         noise_add_pred = yt-torch.sign(-noise_mul_pred * torch.sign(yt)) #predicted additive noise


### PR DESCRIPTION
fix following error:

> factor = (torch.sqrt(self.betas_bar[t])*self.betas[t]/(self.betas_bar[t]+self.betas[t])) #theoretical step size
> RuntimeError: indices should be either on cpu or on the same device as the indexed tensor (cpu)